### PR TITLE
update mdn-browser-compat-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,6 @@
     ]
   },
   "dependencies": {
-    "@mdn/browser-compat-data": "^3.3.14"
+    "@mdn/browser-compat-data": "^5.2.0"
   }
 }

--- a/test/__snapshots__/ast.spec.ts.snap
+++ b/test/__snapshots__/ast.spec.ts.snap
@@ -7,6 +7,7 @@ Object {
   ],
   "compat": Object {
     "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/querySelector",
+    "source_file": "api/Document.json",
     "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-parentnode-queryselector①",
     "status": Object {
       "deprecated": false,
@@ -39,6 +40,9 @@ Object {
           "version_added": "8",
         },
       ],
+      "oculus": Object {
+        "version_added": "5.0",
+      },
       "opera": Object {
         "version_added": "10",
       },
@@ -55,7 +59,7 @@ Object {
         "version_added": "1.0",
       },
       "webview_android": Object {
-        "version_added": "1",
+        "version_added": "4.4",
       },
     },
   },
@@ -79,10 +83,11 @@ Object {
   ],
   "compat": Object {
     "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortController",
+    "source_file": "api/AbortController.json",
     "spec_url": "https://dom.spec.whatwg.org/#interface-abortcontroller",
     "status": Object {
       "deprecated": false,
-      "experimental": true,
+      "experimental": false,
       "standard_track": true,
     },
     "support": Object {
@@ -91,6 +96,9 @@ Object {
       },
       "chrome_android": Object {
         "version_added": "66",
+      },
+      "deno": Object {
+        "version_added": "1.0",
       },
       "edge": Object {
         "version_added": "16",
@@ -106,6 +114,9 @@ Object {
       },
       "nodejs": Object {
         "version_added": "15.0.0",
+      },
+      "oculus": Object {
+        "version_added": "5.0",
       },
       "opera": Object {
         "version_added": "53",
@@ -160,10 +171,11 @@ Object {
   ],
   "compat": Object {
     "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortController",
+    "source_file": "api/AbortController.json",
     "spec_url": "https://dom.spec.whatwg.org/#interface-abortcontroller",
     "status": Object {
       "deprecated": false,
-      "experimental": true,
+      "experimental": false,
       "standard_track": true,
     },
     "support": Object {
@@ -172,6 +184,9 @@ Object {
       },
       "chrome_android": Object {
         "version_added": "66",
+      },
+      "deno": Object {
+        "version_added": "1.0",
       },
       "edge": Object {
         "version_added": "16",
@@ -187,6 +202,9 @@ Object {
       },
       "nodejs": Object {
         "version_added": "15.0.0",
+      },
+      "oculus": Object {
+        "version_added": "5.0",
       },
       "opera": Object {
         "version_added": "53",

--- a/test/__snapshots__/compat.spec.ts.snap
+++ b/test/__snapshots__/compat.spec.ts.snap
@@ -7,10 +7,11 @@ Object {
   ],
   "compat": Object {
     "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortController",
+    "source_file": "api/AbortController.json",
     "spec_url": "https://dom.spec.whatwg.org/#interface-abortcontroller",
     "status": Object {
       "deprecated": false,
-      "experimental": true,
+      "experimental": false,
       "standard_track": true,
     },
     "support": Object {
@@ -19,6 +20,9 @@ Object {
       },
       "chrome_android": Object {
         "version_added": "66",
+      },
+      "deno": Object {
+        "version_added": "1.0",
       },
       "edge": Object {
         "version_added": "16",
@@ -34,6 +38,9 @@ Object {
       },
       "nodejs": Object {
         "version_added": "15.0.0",
+      },
+      "oculus": Object {
+        "version_added": "5.0",
       },
       "opera": Object {
         "version_added": "53",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "emitDeclarationOnly": true,
     "strict": true,
     "pretty": true,
+    "resolveJsonModule": true,
     "sourceMap": true,
     /* Additional Checks */
     "noUnusedLocals": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -551,10 +551,15 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@mdn/browser-compat-data@^3.3.11", "@mdn/browser-compat-data@^3.3.14":
+"@mdn/browser-compat-data@^3.3.11":
   version "3.3.14"
   resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz#b72a37c654e598f9ae6f8335faaee182bebc6b28"
   integrity sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==
+
+"@mdn/browser-compat-data@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-5.2.0.tgz#938f8074437a13e34e435782040b5b337b6cd438"
+  integrity sha512-CVEdy5/Q2cZJXzynD3zpPWHhNpoY1AApKRW0YCWN0HdrlP+VF2+6tX5U5d7XmSL91c2kqdb7yTi93mrAhHX8zw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
This PR updates `@mdn/browser-compat-data` to the latest version and makes sure that the test are passing.

Related to https://github.com/amilajack/eslint-plugin-compat/issues/524.