### PR TITLE
Update @mdn/browser-compat-data to version 5.6.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,6 @@
     ]
   },
   "dependencies": {
-    "@mdn/browser-compat-data": "^5.2.34"
+    "@mdn/browser-compat-data": "^5.6.19"
   }
 }


### PR DESCRIPTION
This PR updates the browser-compat-data to the latest version since a lot of data is missing for eslint-plugin-compat