### PR TITLE
Fix webassembly compat target

### DIFF
--- a/src/providers/mdn/index.ts
+++ b/src/providers/mdn/index.ts
@@ -22,6 +22,11 @@ export default function mdnComaptDataProvider(): ProviderApiMetadata[] {
       name,
       kind: APIKind.Web,
     })),
+    ...Object.entries(browserCompatData.webassembly.api).map(([name, api]) => ({
+      ...api,
+      name,
+      kind: APIKind.Web,
+    })),
     ...Object.entries(browserCompatData.javascript.builtins).map(
       ([name, api]) => ({
         ...api,

--- a/src/providers/mdn/index.ts
+++ b/src/providers/mdn/index.ts
@@ -22,11 +22,11 @@ export default function mdnComaptDataProvider(): ProviderApiMetadata[] {
       name,
       kind: APIKind.Web,
     })),
-    ...Object.entries(browserCompatData.webassembly.api).map(([name, api]) => ({
-      ...api,
-      name,
-      kind: APIKind.Web,
-    })),
+    {
+      name: 'WebAssembly',
+      kind: APIKind.ES,
+      ...browserCompatData.webassembly.api
+    },
     ...Object.entries(browserCompatData.javascript.builtins).map(
       ([name, api]) => ({
         ...api,


### PR DESCRIPTION
Hey @amilajack ,
I noticed the e2e test for [#amilajack/eslint-plugin-compat](https://github.com/amilajack/eslint-plugin-compat) were failing.

I think this is because the webassembly compat was moved inside mdn compat library.
This change allows the test to pass again.

One more thing I noticed is that eslint-plugin-compat is [directly importing](https://github.com/amilajack/eslint-plugin-compat/blob/861e42b90918de5eb2d9d1c1d12b7b63050cc98d/package.json#L70) @mdn/browser-compat-data. I am not 100% sure this is ok.